### PR TITLE
clock: Simulate a tick event on view mount

### DIFF
--- a/app/subviews/clock.js
+++ b/app/subviews/clock.js
@@ -27,6 +27,7 @@ export default class Clock extends View {
 
   onMount() {
     clock.addEventListener("tick", this.handleTick);
+    this.handleTick({ date: new Date() });
   }
 
   handleTick = (evt) => {


### PR DESCRIPTION
Depending on the clock granularity, we may need to wait for the next
tick to happen before having the view rendered, and this may cause a
bigger issue in case we're using minutes granularity.

So simulate this event promptly on view load, so that we don't have to
wait for the tick to happen to render the clock.